### PR TITLE
Disabled eslint rule for extra parantheses for two files

### DIFF
--- a/src/components/CentralList.tsx
+++ b/src/components/CentralList.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-extra-parens */
 import React, { useState } from "react";
 import { Food, FOOD_LIST } from "../interfaces/food";
 import { FoodItem } from "./FoodItem";

--- a/src/components/CustomerCart.tsx
+++ b/src/components/CustomerCart.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-extra-parens */
 import React, { useState } from "react";
 import { Food } from "../interfaces/food";
 


### PR DESCRIPTION
Temporary fix for deployment, disabling the no extra parentheses rule